### PR TITLE
Added striptags module, stripping HTML from feed description on teleg…

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,8 @@ var request = require('request'),
     sqlite3 = require('sqlite3').verbose(),
     HashMap = require('hashmap'),
     botUI = require('./bot.js'),
-    config = require('./config.js');
+    config = require('./config.js'),
+    stripTags = require('striptags');
 
 const TelegramBot = require('node-telegram-bot-api');
 var db = new sqlite3.Database('db.sqlite');
@@ -112,7 +113,9 @@ function match(post, queryKeywords, chatId) {
         // TODO: prevalid Feed-relative hardcoded values and avoid composing 
         //  the notification message with invalid ones
         console.log("Matched!")
-        var description = post["rss:description"]["#"];
+        // Stripping HTML code from description to avoid Telegram complaining,
+        // it possibly needs addition of allowed tags
+        var description = stripTags(post["rss:description"]["#"]);
         var link = post["rss:link"]["#"]
         console.log("Matched " + title + ".Sending notification to " + chatId + ".")
         bot.sendMessage(chatId, "<b>New match!</b> \n" + title + "\n" + description + "\n" + link, {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "node-schedule": "^1.2.1",
     "node-telegram-bot-api": "^0.27.1",
     "request": "^2.81.0",
-    "sqlite3": "^3.1.8"
+    "sqlite3": "^3.1.8",
+    "striptags": "^3.0.1"
   }
 }


### PR DESCRIPTION
…ram notification

Tried to add ```striptags``` module to clean up feed description before passing it to telegram notification (it was complaining on some html descriptions), we can add some **allowed tags** if we need to.
If we need HTML at that point (**line 118** of index.js) or if this is overkill we can just ignore this branch, I'll close it, otherwise we can merge ^^.